### PR TITLE
Add cleaner for outdate message.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,7 +6,7 @@ KIDS_SOURCE = \
 	buffer.h conf.h kids.h msgqueue.h storer.h \
 	client.h constants.h logger.h parser.h util.h \
 	common.h filesystem.h master.h sds.h worker.h \
-	kids.cc \
+	kids.cc transferserver.cc\
 	sds.c util.cc conf.cc logger.cc buffer.cc \
 	master.cc storer.cc worker.cc \
 	msgqueue.cc filesystem.cc \

--- a/src/client.cc
+++ b/src/client.cc
@@ -608,6 +608,8 @@ void Client::ProcessInfo() {
                       "message_out_per_second:%llu\r\n"
                       "message_out_traffic_per_second:%llu\r\n"
                       "message_out_traffic_per_second_human:%s\r\n"
+                      "message_dispatch:%llu\r\n"
+                      "message_dispatch_per_second:%llu\r\n"
                       "message_in_queue:%llu\r\n"
                       "queue_mem_size:%llu\r\n"
                       "queue_mem_size_human:%s\r\n"
@@ -632,6 +634,8 @@ void Client::ProcessInfo() {
                       statistic.msg_out_ps,
                       statistic.msg_out_traffic_ps,
                       msg_out_traffic_ps,
+                      statistic.msg_dispatch,
+                      statistic.msg_dispatch_ps,
                       statistic.msg_in_queue,
                       statistic.queue_mem_size,
                       queue_mem_size,

--- a/src/client.cc
+++ b/src/client.cc
@@ -484,18 +484,24 @@ void Client::ProcessLog() {
 
 void Client::ProcessTransfer() {
   if (argv_.size() != 4) {
-    ReplyErrorFormat("invalid argments of publish");
+    ReplyErrorFormat("invalid argments of transfer");
   } else {
-    LogDebug("processlog(size:%d): %s:%s", sdslen(argv_[2]), argv_[1], argv_[2]);
+    LogDebug("processtransfer(size:%d): %s:%s:%s", sdslen(argv_[3]), argv_[1], argv_[2], argv_[3]);
+    worker_->stat_.msg_in++;
+    worker_->stat_.msg_in_traffic += (sdslen(argv_[1]) + sdslen(argv_[2]));
 
-    if (kids->PutBufferMessage(argv_[1], argv_[2], argv_[3])) {
-      Reply(REP_CONE, REP_CONE_SIZE);
+    if (std::all_of(argv_[1], argv_[1] + sdslen(argv_[1]), ::isdigit)) {
+      if (kids->PutBufferMessage(argv_[1], argv_[2], argv_[3])) {
+        Reply(REP_CONE, REP_CONE_SIZE);
+      } else {
+        ReplyErrorFormat("Some thing bad happens!");
+      }
+      argv_[1] = NULL;
+      argv_[2] = NULL;
+      argv_[3] = NULL;
     } else {
-      ReplyErrorFormat("Some thing bad happens!");
+      ReplyErrorFormat("invalid timestamp!");
     }
-    argv_[1] = NULL;
-    argv_[2] = NULL;
-    argv_[3] = NULL;
   }
 }
 

--- a/src/client.cc
+++ b/src/client.cc
@@ -490,17 +490,27 @@ void Client::ProcessTransfer() {
     worker_->stat_.msg_in++;
     worker_->stat_.msg_in_traffic += (sdslen(argv_[1]) + sdslen(argv_[2]));
 
-    if (std::all_of(argv_[1], argv_[1] + sdslen(argv_[1]), ::isdigit)) {
-      if (kids->PutBufferMessage(argv_[1], argv_[2], argv_[3])) {
+    if (kids->config_.transfer) {
+      if (std::all_of(argv_[1], argv_[1] + sdslen(argv_[1]), ::isdigit)) {
+        if (kids->PutBufferMessage(argv_[1], argv_[2], argv_[3])) {
+          Reply(REP_CONE, REP_CONE_SIZE);
+        } else {
+          ReplyErrorFormat("Some thing bad happens!");
+        }
+        argv_[1] = NULL;
+        argv_[2] = NULL;
+        argv_[3] = NULL;
+      } else {
+        ReplyErrorFormat("invalid timestamp!");
+      }
+    } else {
+      if (kids->PutMessage(argv_[2], argv_[3], worker_->worker_id_)) {
         Reply(REP_CONE, REP_CONE_SIZE);
       } else {
         ReplyErrorFormat("Some thing bad happens!");
       }
-      argv_[1] = NULL;
       argv_[2] = NULL;
       argv_[3] = NULL;
-    } else {
-      ReplyErrorFormat("invalid timestamp!");
     }
   }
 }

--- a/src/client.cc
+++ b/src/client.cc
@@ -434,6 +434,8 @@ bool Client::ProcessCommand() {
     ProcessInfo();
   } else if (!strcasecmp(command, "publish") || !strcasecmp(command, "log")) {
     ProcessLog();
+  } else if (!strcasecmp(command, "transfer")) {
+    ProcessTransfer();
   } else if (!strcasecmp(command, "subscribe")) {
     ProcessSubscribe();
   } else if (!strcasecmp(command, "psubscribe")) {
@@ -479,6 +481,24 @@ void Client::ProcessLog() {
     argv_[2] = NULL;
   }
 }
+
+void Client::ProcessTransfer() {
+  if (argv_.size() != 4) {
+    ReplyErrorFormat("invalid argments of publish");
+  } else {
+    LogDebug("processlog(size:%d): %s:%s", sdslen(argv_[2]), argv_[1], argv_[2]);
+
+    if (kids->PutBufferMessage(argv_[1], argv_[2], argv_[3])) {
+      Reply(REP_CONE, REP_CONE_SIZE);
+    } else {
+      ReplyErrorFormat("Some thing bad happens!");
+    }
+    argv_[1] = NULL;
+    argv_[2] = NULL;
+    argv_[3] = NULL;
+  }
+}
+
 
 void Client::ProcessOther() {
   static const char *redis_cmd[] = {

--- a/src/client.h
+++ b/src/client.h
@@ -51,6 +51,7 @@ class Client {
   void ProcessInfo();
   void ProcessQuit();
   void ProcessLog();
+  void ProcessTransfer();
   void ProcessSubscribe();
   void ProcessPSubscribe();
   void ProcessUnSubscribe(bool notify);

--- a/src/common.h
+++ b/src/common.h
@@ -55,13 +55,14 @@ typedef struct Statistic {
   uint64_t msg_out_traffic;
   uint64_t msg_out_ps;
   uint64_t msg_out_traffic_ps;
+  uint64_t msg_dispatch;
+  uint64_t msg_dispatch_ps;
   uint64_t msg_in_queue;
   uint64_t queue_mem_size;
   uint64_t msg_store;
   uint64_t msg_store_size;
   uint64_t msg_buffer;
   uint64_t msg_buffer_size;
-  uint64_t msg_dispatch;
   uint64_t msg_drop;
   uint64_t clients;
   uint64_t topics;

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,7 @@ typedef struct Statistic {
     msg_store_size     = 0;
     msg_buffer         = 0;
     msg_buffer_size    = 0;
+    msg_dispatch       = 0;
     msg_drop           = 0;
     clients            = 0;
     topics             = 0;
@@ -38,6 +39,7 @@ typedef struct Statistic {
     msg_store_size  += stat.msg_store_size;
     msg_buffer      += stat.msg_buffer;
     msg_buffer_size += stat.msg_buffer_size;
+    msg_dispatch    += stat.msg_dispatch;
     msg_drop        += stat.msg_drop;
     clients         += stat.clients;
     topics          += stat.topics;
@@ -59,6 +61,7 @@ typedef struct Statistic {
   uint64_t msg_store_size;
   uint64_t msg_buffer;
   uint64_t msg_buffer_size;
+  uint64_t msg_dispatch;
   uint64_t msg_drop;
   uint64_t clients;
   uint64_t topics;

--- a/src/conf.cc
+++ b/src/conf.cc
@@ -43,6 +43,8 @@ static void SetKidsConfValue(KidsConfig *conf, KeyValue *kv, ParseContext *ctx) 
     conf->max_clients = kv->value[0];
   } else if (kv->key == "worker_threads") {
     conf->worker_threads = kv->value[0];
+  } else if (kv->key == "transfer") {
+    conf->transfer = kv->value[0];
   } else if (kv->key == "ignore_case") {
     conf->ignore_case = kv->value[0];
   } else if (kv->key == "nlimit") {

--- a/src/conf.h
+++ b/src/conf.h
@@ -47,6 +47,7 @@ struct KidsConfig {
   std::string max_clients;
   std::string worker_threads;
   std::string ignore_case;
+  std::string transfer;
   LimitConfig nlimit[3];
   StoreConfig *store;
 };

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -119,10 +119,21 @@ void DeleteOldestFile(const char *path) {
   }
 }
 
-std::string RetrieveDateFromPath(const std::string &path) {
+int RetrieveDateFromPath(const std::string &path) {
   unsigned pos = path.find_last_of("/");
   std::string filename = path.substr(pos + 1);
-  return filename.substr(0, sizeof("2000-12-34-56-78-90") - 1);
+  std::string date =  filename.substr(0, sizeof("2000-12-34-56-78-90") - 1);
+  int year, mon, day, hour, min, sec;
+  sscanf(date.c_str(), "%4d-%2d-%2d-%2d-%2d-%2d", &year, &mon, &day, &hour, &min, &sec);
+  struct tm tm;
+  memset(&tm, 0, sizeof(tm));
+  tm.tm_year = year - 1900;
+  tm.tm_mon  = mon - 1;
+  tm.tm_mday = day;
+  tm.tm_hour = hour;
+  tm.tm_min  = min;
+  tm.tm_sec  = sec;
+  return mktime(&tm);
 }
 
 std::string MakeName(std::string pattern, const struct tm& tm, std::string topic) {

--- a/src/filesystem.cc
+++ b/src/filesystem.cc
@@ -119,6 +119,12 @@ void DeleteOldestFile(const char *path) {
   }
 }
 
+std::string RetrieveDateFromPath(const std::string &path) {
+  unsigned pos = path.find_last_of("/");
+  std::string filename = path.substr(pos + 1);
+  return filename.substr(0, sizeof("2000-12-34-56-78-90") - 1);
+}
+
 std::string MakeName(std::string pattern, const struct tm& tm, std::string topic) {
   char buffer[100];
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -34,7 +34,7 @@ class File {
 
 std::string MakeName(std::string pattern, const struct tm& tm, std::string topic);
 std::string FindRoot(std::string pattern);
-std::string RetrieveDateFromPath(const std::string &Path);
+int RetrieveDateFromPath(const std::string &Path);
 
 bool MakePath(const char *path, mode_t mode);
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -34,6 +34,7 @@ class File {
 
 std::string MakeName(std::string pattern, const struct tm& tm, std::string topic);
 std::string FindRoot(std::string pattern);
+std::string RetrieveDateFromPath(const std::string &Path);
 
 bool MakePath(const char *path, mode_t mode);
 

--- a/src/kids.h
+++ b/src/kids.h
@@ -29,6 +29,7 @@
 #include "master.h"
 #include "storer.h"
 #include "store/store.h"
+#include "transferserver.h"
 #include "sds.h"
 #include "util.h"
 #include "worker.h"

--- a/src/master.cc
+++ b/src/master.cc
@@ -127,6 +127,7 @@ Master::~Master() {
     delete it;
   }
   delete storer_;
+  delete transfer_server_;
 
   if (unixfd_ > 0) {
     close(unixfd_);

--- a/src/master.cc
+++ b/src/master.cc
@@ -224,6 +224,7 @@ void Master::Cron() {
   unixtime                         = time(nullptr);
   static uint64_t last_in          = 0;
   static uint64_t last_out         = 0;
+  static uint64_t last_dispatch    = 0;
   static uint64_t last_in_traffic  = 0;
   static uint64_t last_out_traffic = 0;
   static time_t   last_time        = 0;
@@ -250,6 +251,7 @@ void Master::Cron() {
   stat.start_time         = stat_.start_time;
   stat.msg_in_ps          = stat_.msg_in_ps;
   stat.msg_out_ps         = stat_.msg_out_ps;
+  stat.msg_dispatch_ps    = stat_.msg_dispatch_ps;
   stat.msg_in_traffic_ps  = stat_.msg_in_traffic_ps;
   stat.msg_out_traffic_ps = stat_.msg_out_traffic_ps;
   stat.msg_drop           = stat_.msg_drop;
@@ -257,6 +259,7 @@ void Master::Cron() {
   if (unixtime - last_time >= 5) {
     stat.msg_in_ps = (stat.msg_in - last_in) / (unixtime - last_time);
     stat.msg_out_ps = (stat.msg_out - last_out) / (unixtime - last_time);
+    stat.msg_dispatch_ps = (stat.msg_dispatch - last_dispatch) / (unixtime - last_time);
     stat.msg_in_traffic_ps = (stat.msg_in_traffic - last_in_traffic) / (unixtime - last_time);
     stat.msg_out_traffic_ps = (stat.msg_out_traffic - last_out_traffic) / (unixtime - last_time);
 

--- a/src/master.cc
+++ b/src/master.cc
@@ -265,6 +265,7 @@ void Master::Cron() {
 
     last_in = stat.msg_in;
     last_out = stat.msg_out;
+    last_dispatch = stat.msg_dispatch;
     last_in_traffic = stat.msg_in_traffic;
     last_out_traffic = stat.msg_out_traffic;
     last_time = unixtime;

--- a/src/master.h
+++ b/src/master.h
@@ -27,6 +27,7 @@ class Master {
     std::string listen_host;
     int listen_port;
     bool ignore_case;
+    bool transfer;
     int max_clients;
     LimitConfig nlimit[3];
     uint64_t queue_limit;

--- a/src/master.h
+++ b/src/master.h
@@ -17,6 +17,7 @@ typedef struct MessageQueue MQ;
 struct aeEventLoop;
 class Storer;
 class Worker;
+class TransferServer;
 
 class Master {
  public:
@@ -36,6 +37,7 @@ class Master {
 
   void AssignNewConnection(const int fd);
   bool PutMessage(const sds &topic, const sds &content, const int worker_id);
+  bool PutBufferMessage(const sds &date, const sds &topic, const sds &content);
 
   void NotifyNewMessage(const int worker_id);
 
@@ -57,6 +59,8 @@ class Master {
 
   std::unordered_map<std::string, uint16_t> connected_clients_;
   std::mutex clients_mtx_;
+
+  TransferServer *transfer_server_;
 
   Storer *storer_;
   MQ *message_queue_;

--- a/src/store/bufferstore.cc
+++ b/src/store/bufferstore.cc
@@ -110,7 +110,7 @@ void BufferStore::Cron() {
       BufferedMessage buffered_msg = msg_to_transfer_->front();
       msg_to_transfer_->pop_front();
       cnt++;
-      if (primary_->TransferMessage(buffered_msg.msg, buffered_msg.date)) {
+      if (primary_->TransferMessage(buffered_msg.msg, buffered_msg.timestamp)) {
         LogDebug("Transfer a bufferred msg, queue: %d remains total %d", msg_to_transfer_->size(), stat_->msg_buffer);
       } else {
         LogError("Transfer a bufferred message failed");

--- a/src/store/bufferstore.cc
+++ b/src/store/bufferstore.cc
@@ -30,7 +30,7 @@ bool BufferStore::Open() {
   if (primary_->Open()) {
     if (secondary_->HaveOldMessage()) {
       state_ = kTransfering;
-      msg_to_transfer_ = new std::deque<const Message*>();
+      msg_to_transfer_ = new std::deque<BufferedMessage>();
     } else {
       state_ = kToPrimary;
     }
@@ -57,7 +57,7 @@ void BufferStore::Close() {
   if (msg_to_transfer_ != NULL && msg_to_transfer_->size() > 0) {
     LogWarning("close store, delete %d bufferred msg", msg_to_transfer_->size());
     while (!msg_to_transfer_->empty()) {
-      delete msg_to_transfer_->front();
+      delete msg_to_transfer_->front().msg;
       msg_to_transfer_->pop_front();
 
       stat_->msg_drop++;
@@ -72,7 +72,7 @@ bool BufferStore::DoAddMessage(const Message *msg) {
   if (state_ == kToSecondary) LogDebug("state: kSecondary");
   if (state_ == kTransfering) LogDebug("state: kTransfering");
 
-  if (state_ == kToPrimary) {
+  if (state_ == kToPrimary || state_ == kTransfering) {
     if (!primary_->IsOpen() || !primary_->AddMessage(msg)) {
       LogInfo("Store to primary store faild, switch to secondary");
       secondary_->Open();
@@ -80,12 +80,11 @@ bool BufferStore::DoAddMessage(const Message *msg) {
     }
   }
 
-  if (state_ == kToSecondary || state_ == kTransfering) {
+  if (state_ == kToSecondary) {
     LogDebug("store to secondary store");
     if (!secondary_->IsOpen()) secondary_->Open();
     if (!secondary_->AddMessage(msg)) {
       LogError("Drop message: %s", ERR_SEND_SECONDARY);
-
       stat_->msg_drop++;
       return false;
     }
@@ -100,7 +99,7 @@ void BufferStore::Cron() {
     if (primary_->IsOpen()) {
       LogInfo("Primary store opened, switch to transfering");
       state_ = kTransfering;
-      msg_to_transfer_ = new std::deque<const Message*>();
+      msg_to_transfer_ = new std::deque<BufferedMessage>();
     }
   }
 
@@ -108,19 +107,19 @@ void BufferStore::Cron() {
     // send memory bufferred buffer first
     int cnt = 0;
     while (!msg_to_transfer_->empty() && cnt < max_msg_per_cron_) {
-      const Message *msg = msg_to_transfer_->front();
+      BufferedMessage buffered_msg = msg_to_transfer_->front();
       msg_to_transfer_->pop_front();
       cnt++;
-      if (primary_->AddMessage(msg)) {
+      if (primary_->TransferMessage(buffered_msg.msg, buffered_msg.date)) {
         LogDebug("Transfer a bufferred msg, queue: %d remains total %d", msg_to_transfer_->size(), stat_->msg_buffer);
       } else {
         LogError("Transfer a bufferred message failed");
         stat_->msg_buffer--;
-        delete msg;
+        delete buffered_msg.msg;
         break;
       }
       stat_->msg_buffer--;
-      delete msg;
+      delete buffered_msg.msg;
     }
 
     // read a file bufferred buffer

--- a/src/store/bufferstore.h
+++ b/src/store/bufferstore.h
@@ -33,7 +33,7 @@ class BufferStore : public Store {
   Store *primary_;
   Store *secondary_;
   Status state_;
-  std::deque<const Message*> *msg_to_transfer_;
+  std::deque<Store::BufferedMessage> *msg_to_transfer_;
   bool is_open_;
   int max_msg_per_cron_;
 };

--- a/src/store/filestore.cc
+++ b/src/store/filestore.cc
@@ -131,7 +131,7 @@ bool FileStore::HaveOldMessage() {
   return !filename.empty();
 }
 
-int FileStore::GetOldestMessages(std::deque<const Message*> *msgs) {
+int FileStore::GetOldestMessages(std::deque<BufferedMessage> *msgs) {
   int size, cnt = 0;
 
   std::string filename = FindOldestFile(path_.c_str());
@@ -153,7 +153,9 @@ int FileStore::GetOldestMessages(std::deque<const Message*> *msgs) {
 
     if (!content || !file->Read(content, size)) goto ERR;
 
-    msgs->push_back(new Message(topic, content));
+    if (filename.size() < sizeof("2000-12-34-56-78-90") - 1) goto ERR;
+
+    msgs->push_back({ .msg = new Message(topic, content), .date = RetrieveDateFromPath(filename)});
     cnt++;
     continue;
 ERR:

--- a/src/store/filestore.cc
+++ b/src/store/filestore.cc
@@ -155,7 +155,7 @@ int FileStore::GetOldestMessages(std::deque<BufferedMessage> *msgs) {
 
     if (filename.size() < sizeof("2000-12-34-56-78-90") - 1) goto ERR;
 
-    msgs->push_back({ .msg = new Message(topic, content), .date = RetrieveDateFromPath(filename)});
+    msgs->push_back({ new Message(topic, content), RetrieveDateFromPath(filename)});
     cnt++;
     continue;
 ERR:

--- a/src/store/filestore.h
+++ b/src/store/filestore.h
@@ -20,7 +20,7 @@ class FileStore : public Store {
   virtual void Cron();
 
   virtual bool HaveOldMessage();
-  virtual int GetOldestMessages(std::deque<const Message*> *msgs);
+  virtual int GetOldestMessages(std::deque<BufferedMessage> *msgs);
   virtual void DeleteOldestMessages();
 
  private:

--- a/src/store/networkstore.cc
+++ b/src/store/networkstore.cc
@@ -110,7 +110,7 @@ void NetworkStore::Agent::Transfer(const Message *msg, int timestamp) {
   req_.append_printf("*4\r\n");
   req_.append_printf("$8\r\nTRANSFER\r\n");
 
-  req_.append_printf("$%d\r\n%d\r\n", timestamp, n);
+  req_.append_printf("$%d\r\n%d\r\n", n, timestamp);
   req_.append_printf("$%d\r\n", sdslen(msg->topic));
   req_.append(msg->topic, sdslen(msg->topic));
   req_.append("\r\n", 2);

--- a/src/store/networkstore.cc
+++ b/src/store/networkstore.cc
@@ -13,6 +13,7 @@ class NetworkStore::Agent {
   std::string ToString();
 
   void Log(const Message *msg);
+  void Transfer(const Message *msg, const std::string &date);
   aeEventLoop *eventl_;
 
  private:
@@ -88,6 +89,27 @@ void NetworkStore::Agent::Log(const Message *msg) {
   req_.append_printf("$%d\r\n", sdslen(msg->content));
   req_.append(msg->content, sdslen(msg->content));
   req_.append("\r\n", 2);
+  store_->stat_->msg_dispatch++;
+}
+
+void NetworkStore::Agent::Transfer(const Message *msg, const std::string &date) {
+  if (!SetWriteEvent()) {
+    LogError("set write event failed");
+    return;
+  }
+
+  LogDebug("transfer to remote server, req buflen: %d, data: %s:%s", req_.size(), msg->topic, msg->content);
+
+  req_.append_printf("*4\r\n");
+  req_.append_printf("$8\r\nTRANSFER\r\n");
+  req_.append_printf("$%lu\r\n%s\r\n", date.size(), date.c_str());
+  req_.append_printf("$%d\r\n", sdslen(msg->topic));
+  req_.append(msg->topic, sdslen(msg->topic));
+  req_.append("\r\n", 2);
+  req_.append_printf("$%d\r\n", sdslen(msg->content));
+  req_.append(msg->content, sdslen(msg->content));
+  req_.append("\r\n", 2);
+  store_->stat_->msg_dispatch++;
 }
 
 bool NetworkStore::Agent::ParseReplyBuffer() {
@@ -156,7 +178,7 @@ bool NetworkStore::Agent::ProcessResult() {
   return true;
 }
 
-NetworkStore::NetworkStore(StoreConfig *conf, aeEventLoop *el) :Store(conf), eventl_(el) {
+NetworkStore::NetworkStore(StoreConfig *conf, struct Statistic *stat,  aeEventLoop *el) :Store(conf), eventl_(el), stat_(stat) {
   agent_ = NULL;
   reconnect_interval_ = 5;
   last_reconnect_ = 0;
@@ -220,6 +242,14 @@ bool NetworkStore::DoAddMessage(const Message *msg) {
   if (!IsOpen()) return false;
   LogDebug("add message %p", msg);
   agent_->Log(msg);
+  state_ = Store::Sending;
+  return true;
+}
+
+bool NetworkStore::DoTransferMessage(const Message *msg, const std::string &date) {
+  if (!IsOpen()) return false;
+  LogDebug("transfer message %p with datestamp %s", msg, date.c_str());
+  agent_->Transfer(msg, date);
   state_ = Store::Sending;
   return true;
 }

--- a/src/store/networkstore.h
+++ b/src/store/networkstore.h
@@ -11,7 +11,7 @@ class NetworkStore : public Store {
  public:
   class Agent;
 
-  NetworkStore(StoreConfig *conf, aeEventLoop *el);
+  NetworkStore(StoreConfig *conf, struct Statistic *stat, aeEventLoop *el);
   ~NetworkStore();
 
   virtual bool Open();
@@ -28,11 +28,11 @@ class NetworkStore : public Store {
   aeEventLoop *eventl_;
 
  private:
-  NetworkStore() = delete;
+  Agent *agent_;
+  NetworkStore();
 
   virtual bool DoAddMessage(const Message *msg);
-
-  Agent *agent_;
+  virtual bool DoTransferMessage(const Message *msg, const std::string &date);
 
   std::string host_;
   int port_;
@@ -41,6 +41,7 @@ class NetworkStore : public Store {
   time_t reconnect_interval_;
   time_t last_reconnect_;
 
+  struct Statistic *stat_;
   std::list<const Message*> msg_chain_;
   std::list<bool> del_chain_;
   Store::StoreState state_;

--- a/src/store/networkstore.h
+++ b/src/store/networkstore.h
@@ -32,7 +32,7 @@ class NetworkStore : public Store {
   NetworkStore();
 
   virtual bool DoAddMessage(const Message *msg);
-  virtual bool DoTransferMessage(const Message *msg, const std::string &date);
+  virtual bool DoTransferMessage(const Message *msg, int timestamp);
 
   std::string host_;
   int port_;

--- a/src/store/store.cc
+++ b/src/store/store.cc
@@ -13,7 +13,7 @@ Store *Store::Create(StoreConfig *conf, struct Statistic *stat, aeEventLoop *el)
   } else if (conf->type == "buffer") {
     store = new BufferStore(conf, stat, el);
   } else if (conf->type == "network") {
-    store = new NetworkStore(conf, el);
+    store = new NetworkStore(conf, stat, el);
   } else if (conf->type == "file") {
     store = new FileStore(conf, stat);
   } else if (conf->type == "null") {
@@ -48,6 +48,14 @@ bool Store::AddMessage(const Message *msg) {
   if (PreAddMessage(msg)) {
     LogDebug("pre check ok");
     return DoAddMessage(msg);
+  }
+  return false;
+}
+
+bool Store::TransferMessage(const Message *msg, const std::string &date) {
+  if (PreAddMessage(msg)) {
+    LogDebug("pre check ok");
+    return DoTransferMessage(msg, date);
   }
   return false;
 }

--- a/src/store/store.cc
+++ b/src/store/store.cc
@@ -52,10 +52,10 @@ bool Store::AddMessage(const Message *msg) {
   return false;
 }
 
-bool Store::TransferMessage(const Message *msg, const std::string &date) {
+bool Store::TransferMessage(const Message *msg, int timestamp) {
   if (PreAddMessage(msg)) {
     LogDebug("pre check ok");
-    return DoTransferMessage(msg, date);
+    return DoTransferMessage(msg, timestamp);
   }
   return false;
 }

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -28,14 +28,14 @@ class Store {
   virtual void Close() = 0;
 
   virtual bool AddMessage(const Message *msg);
-  virtual bool TransferMessage(const Message *msg, const std::string &date);
+  virtual bool TransferMessage(const Message *msg, int timestamp);
   virtual bool HaveOldMessage() { return false; }
 
   virtual StoreState State() { return Free; }
 
   struct BufferedMessage {
     const Message *msg;
-    std::string date;
+    int timestamp;
   };
 
   virtual int GetOldestMessages(std::deque<BufferedMessage> *msgs) {
@@ -56,9 +56,9 @@ class Store {
 
  private:
   virtual bool DoAddMessage(const Message *msg) = 0;
-  virtual bool DoTransferMessage(const Message *msg, const std::string &date) {
+  virtual bool DoTransferMessage(const Message *msg, int timestamp) {
     ((void) msg);
-    ((void) date);
+    ((void) timestamp);
     return true;
   }
   bool PreAddMessage(const Message *msg);

--- a/src/store/store.h
+++ b/src/store/store.h
@@ -28,10 +28,20 @@ class Store {
   virtual void Close() = 0;
 
   virtual bool AddMessage(const Message *msg);
-
+  virtual bool TransferMessage(const Message *msg, const std::string &date);
   virtual bool HaveOldMessage() { return false; }
+
   virtual StoreState State() { return Free; }
-  virtual int GetOldestMessages(std::deque<const Message*> *msgs) { return 0; }
+
+  struct BufferedMessage {
+    const Message *msg;
+    std::string date;
+  };
+
+  virtual int GetOldestMessages(std::deque<BufferedMessage> *msgs) {
+    ((void) msgs);
+    return 0;
+  }
   virtual void DeleteOldestMessages() {}
 
   virtual void Cron() {}
@@ -46,6 +56,11 @@ class Store {
 
  private:
   virtual bool DoAddMessage(const Message *msg) = 0;
+  virtual bool DoTransferMessage(const Message *msg, const std::string &date) {
+    ((void) msg);
+    ((void) date);
+    return true;
+  }
   bool PreAddMessage(const Message *msg);
 
   std::string topic_;
@@ -53,14 +68,17 @@ class Store {
 
 class NullStore : public Store {
  public:
-  explicit NullStore(StoreConfig *conf) : Store(conf), is_open_(false) {}
+  NullStore(StoreConfig *conf) : Store(conf), is_open_(false) {}
 
   virtual bool Open() { is_open_ = true; return true; }
   virtual bool IsOpen() { return is_open_; }
   virtual void Close() { is_open_ = false; }
 
  private:
-  virtual bool DoAddMessage(const Message *msg) { return true; }
+  virtual bool DoAddMessage(const Message *msg) {
+    ((void) msg);
+    return true;
+  }
 
   bool is_open_;
 };

--- a/src/transferserver.cc
+++ b/src/transferserver.cc
@@ -1,0 +1,116 @@
+#include <vector>
+#include <algorithm>
+#include "kids.h"
+#include "transferserver.h"
+#define NOTUSED(V) ((void *)V)
+
+static void *TransferServerMain(void *args) {
+  aeMain(static_cast<aeEventLoop *>(args));
+  return nullptr;
+}
+
+static int Cron(struct aeEventLoop *el, long long id, void *clientData) {
+  NOTUSED(el);
+  NOTUSED(id);
+  TransferServer *transfer_server = static_cast<TransferServer *>(clientData);
+  return transfer_server->Cron();
+}
+
+bool TransferServer::AppendMessage(const BufferedMessage &msg) {
+  bool success = false;
+  int t = atoi(msg.timestamp);
+  if (rotate_interval_ > 0)
+    t -= t % rotate_interval_;
+  File *file = File::Open(path_, name_, false, std::string(msg.topic), t);
+  success = file->Write(msg.content, sdslen(msg.content), false, true);
+  file->Close(true);
+  delete file;
+
+  sdsfree(msg.timestamp);
+  sdsfree(msg.topic);
+  sdsfree(msg.content);
+
+  return success;
+}
+
+int TransferServer::Cron() {
+  int count = 0;
+  std::vector<BufferedMessage> msg_queue;
+  msg_queue.reserve(kMaxMessagePerCron);
+
+  {
+    std::lock_guard<std::mutex> _(buffer_queue_lock_);
+    while (count < msg_per_cron) {
+      if (buffer_message_queue_.size() == 0)
+        break;
+      auto msg = buffer_message_queue_.front();
+
+      buffer_message_queue_.pop_front();
+      msg_queue.push_back(msg);
+      count++;
+    }
+  }
+
+  std::vector<BufferedMessage> fresh_msgs;
+  for (auto i : msg_queue) {
+    auto timestamp = atoi(i.timestamp);
+    if (timestamp <= 0) {
+      LogWarning("Error transfer command");
+    } else if (time(nullptr) - timestamp < 4000) {
+      fresh_msgs.push_back(i);
+    } else {
+      if (!AppendMessage(i))
+        LogError("Appending buffered messge to file failed!");
+    }
+  }
+
+  std::lock_guard<std::mutex> _(buffer_queue_lock_);
+  for (auto i : fresh_msgs)
+    buffer_message_queue_.push_back(i);
+  return kInitCronPeriod;
+}
+
+void TransferServer::Stop() {
+  el->stop = 1;
+  pthread_join(transfer_tid_, nullptr);
+}
+
+TransferServer::TransferServer() {
+  el = aeCreateEventLoop(10);
+  period       = kInitCronPeriod;
+  msg_per_cron = kMaxMessagePerCron;
+}
+
+bool TransferServer::PutBufferMessage(const sds &date, const sds &topic, const sds &content) {
+  std::lock_guard<std::mutex> _(buffer_queue_lock_);
+  buffer_message_queue_.push_back({date, topic, content});
+  LogInfo("%s pushed", topic);
+  return true;
+}
+
+void TransferServer::Start() {
+  pthread_create(&transfer_tid_, nullptr, TransferServerMain, el);
+}
+
+TransferServer *TransferServer::Create(StoreConfig *conf) {
+  TransferServer *server = new TransferServer;
+  server->path_ = conf->path;
+  server->name_ = conf->name;
+
+  if (server->path_.back() != '/') {
+    server->path_ += "/";
+  }
+
+  int rotate_interval_;
+  if (conf->rotate == "daily") {
+    rotate_interval_ = 3600 * 24;
+  } else if (conf->rotate == "hourly") {
+    rotate_interval_ = 3600;
+  } else if (!ParseTime(conf->rotate.c_str(), &rotate_interval_)) {
+    rotate_interval_ = -1;
+  }
+
+  server->rotate_interval_ = rotate_interval_;
+  server->clean_cron_id = aeCreateTimeEvent(server->el, 5000, ::Cron, server, nullptr);
+  return server;
+}

--- a/src/transferserver.cc
+++ b/src/transferserver.cc
@@ -1,7 +1,9 @@
 #include <vector>
 #include <algorithm>
+#include <memory>
 #include "kids.h"
 #include "transferserver.h"
+
 #define NOTUSED(V) ((void *)V)
 
 static void *TransferServerMain(void *args) {
@@ -21,10 +23,8 @@ bool TransferServer::AppendMessage(const BufferedMessage &msg) {
   int timestamp = atoi(msg.timestamp);
   if (rotate_interval_ > 0)
     timestamp -= timestamp % rotate_interval_;
-  File *file = File::Open(path_, name_, false, std::string(msg.topic), timestamp);
+  auto file = std::unique_ptr<File>(File::Open(path_, name_, false, std::string(msg.topic), timestamp));
   success = file->Write(msg.content, sdslen(msg.content), false, true);
-  file->Close(true);
-  delete file;
 
   sdsfree(msg.timestamp);
   sdsfree(msg.topic);

--- a/src/transferserver.cc
+++ b/src/transferserver.cc
@@ -84,7 +84,6 @@ TransferServer::TransferServer() {
 bool TransferServer::PutBufferMessage(const sds &date, const sds &topic, const sds &content) {
   std::lock_guard<std::mutex> _(buffer_queue_lock_);
   buffer_message_queue_.push_back({date, topic, content});
-  LogInfo("%s pushed", topic);
   return true;
 }
 

--- a/src/transferserver.cc
+++ b/src/transferserver.cc
@@ -105,6 +105,7 @@ bool TransferServer::PutBufferMessage(const sds &date, const sds &topic, const s
 }
 
 void TransferServer::Start() {
+  LogInfo("Transfer server started, \"transfer\" command is now supported");
   pthread_create(&transfer_tid_, nullptr, TransferServerMain, el_);
 }
 

--- a/src/transferserver.h
+++ b/src/transferserver.h
@@ -1,0 +1,52 @@
+#ifndef __KIDS_TRANSFERSERVER_H
+#define __KIDS_TRANSFERSERVER_H
+
+#include <mutex>
+#include <unordered_map>
+#include <deque>
+
+#include "filesystem.h"
+#include "common.h"
+
+typedef char *sds;
+struct aeEventLoop;
+struct StoreConfig;
+
+struct BufferedMessage {
+  sds timestamp;
+  sds topic;
+  sds content;
+};
+
+class TransferServer {
+ public:
+  static const int kMaxMessagePerCron = 100;
+  static const int kInitCronPeriod    = 5000;
+  using TopicFile = std::unordered_map<sds, File*, SdsHasher, SdsEqual>;
+
+  static TransferServer *Create(StoreConfig *conf);
+
+  void Start();
+  void Stop();
+  int Cron();
+
+  bool AppendMessage(const BufferedMessage &msg);
+  bool PutBufferMessage(const sds &date, const sds &topic, const sds &content);
+
+ private:
+  TransferServer();
+
+  std::mutex buffer_queue_lock_;
+  std::deque<BufferedMessage> buffer_message_queue_;
+
+  int period;
+  int msg_per_cron;
+  pthread_t transfer_tid_;
+  aeEventLoop *el;
+  long long clean_cron_id;
+  std::string path_;
+  std::string name_;
+  int rotate_interval_;
+};
+
+#endif /* __KIDS_TRANSFERSERVER_H */

--- a/src/transferserver.h
+++ b/src/transferserver.h
@@ -12,15 +12,14 @@ typedef char *sds;
 struct aeEventLoop;
 struct StoreConfig;
 
-
 class TransferServer {
  public:
   static const int kMaxMessagePerCron = 100;
   static const int kInitCronPeriod    = 5000;
   static const int kMaxCronPeriod     = 600000;
-  using TopicFile = std::unordered_map<sds, File*, SdsHasher, SdsEqual>;
 
   static TransferServer *Create(StoreConfig *conf);
+  ~TransferServer();
 
   struct BufferedMessage {
     sds timestamp;
@@ -42,8 +41,8 @@ class TransferServer {
   std::deque<BufferedMessage> buffer_message_queue_;
 
   pthread_t transfer_tid_;
-  aeEventLoop *el;
-  long long clean_cron_id;
+  aeEventLoop *el_;
+  long long clean_cron_id_;
   std::string path_;
   std::string name_;
   int rotate_interval_;

--- a/src/transferserver.h
+++ b/src/transferserver.h
@@ -12,19 +12,21 @@ typedef char *sds;
 struct aeEventLoop;
 struct StoreConfig;
 
-struct BufferedMessage {
-  sds timestamp;
-  sds topic;
-  sds content;
-};
 
 class TransferServer {
  public:
   static const int kMaxMessagePerCron = 100;
   static const int kInitCronPeriod    = 5000;
+  static const int kMaxCronPeriod     = 600000;
   using TopicFile = std::unordered_map<sds, File*, SdsHasher, SdsEqual>;
 
   static TransferServer *Create(StoreConfig *conf);
+
+  struct BufferedMessage {
+    sds timestamp;
+    sds topic;
+    sds content;
+  };
 
   void Start();
   void Stop();
@@ -39,8 +41,6 @@ class TransferServer {
   std::mutex buffer_queue_lock_;
   std::deque<BufferedMessage> buffer_message_queue_;
 
-  int period;
-  int msg_per_cron;
   pthread_t transfer_tid_;
   aeEventLoop *el;
   long long clean_cron_id;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -30,6 +30,7 @@ KIDS_SOURCE = @top_srcdir@/src/store/store.cc \
 							@top_srcdir@/src/storer.cc \
 							@top_srcdir@/src/sds.c \
 							@top_srcdir@/src/util.cc \
+							@top_srcdir@/src/transferserver.cc \
 							@top_srcdir@/src/kids.h
 
 GTEST_SOURCE = gtest/gtest-all.cc \


### PR DESCRIPTION
In previous version, kids agent would mix the outdated messages with newest messages. So, the subscriber of kids server will be confused by the mixed messages.
