### PR TITLE
reload store config by SIGHUP

### DIFF
--- a/src/master.cc
+++ b/src/master.cc
@@ -211,6 +211,10 @@ void Master::Stop() {
   storer_->Stop();
 }
 
+void Master::ReloadStoreConfig(const KidsConfig* conf) {
+  storer_->RefreshConfig(conf->store);
+}
+
 void Master::Cron() {
   unixtime                         = time(nullptr);
   static uint64_t last_in          = 0;

--- a/src/master.h
+++ b/src/master.h
@@ -44,6 +44,7 @@ class Master {
 
   void Start();
   void Stop();
+  void ReloadStoreConfig(const KidsConfig* conf);
   void Cron();
 
   const Config config_;

--- a/src/storer.h
+++ b/src/storer.h
@@ -3,6 +3,7 @@
 
 #include <pthread.h>
 #include <deque>
+#include <atomic>
 
 #include "ae/libae.h"
 #include "common.h"
@@ -25,6 +26,7 @@ class Storer {
 
   void AddNotify(const int worker_id);
   void NotifyNewMessage(const int worker_id);
+  void RefreshConfig(StoreConfig *conf);
   void StoreMessage(const int fd);
   MQItem* GetCursorPosition();
 
@@ -36,7 +38,10 @@ class Storer {
   aeEventLoop *eventl_;
 
  private:
-  Storer(MQCursor* cursor, const int num_workers);
+  Storer(StoreConfig * conf, MQCursor* cursor, const int num_workers);
+
+  bool IfConfigRefreshed();
+  void DoConfigReload();
 
   MQCursor *cursor_;
 
@@ -44,6 +49,9 @@ class Storer {
   int *msg_wait_to_notify_;
   int *msg_notify_send_fd_;
   int *msg_notify_receive_fd_;
+
+  std::atomic_flag conf_loaded_;
+  StoreConfig *conf_;
 
   Store *store_;
   long long timeid_;


### PR DESCRIPTION
send SIGHUP to reload kids config file, which would change `store` part behaviors while leave other things untouched.

buffer file would be closed immediately and users have to take care of them, to make sure the new config would not mess up the old buffer files.

to be honest I tried to make the config migration more smoothly, like rename buffer file, or make threads number also changeable. but all of them turn out to be too complex or result in quite weird logic. so I think this patch should be enough for most real world use cases.