### PR TITLE
Fix docker build error.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,0 @@
-doc/
-test/
-tools/
-client/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,3 @@ RUN ./autogen.sh && ./configure && make
 EXPOSE :3388
 
 CMD ["src/kids", "-c", "/kids/debian/kids.conf"]
-


### PR DESCRIPTION
The error is as follows:

src/Makefile.am: installing ./depcomp' configure.ac:83: required filedoc/Makefile.in' not found
configure.ac:83: required file `test/Makefile.in' not found
Makefile.am:1: required directory ./doc does not exist
Makefile.am:1: required directory ./test does not exist
autoreconf: automake failed with exit status: 1
INFO[0010] The command [/bin/sh -c ./autogen.sh && ./configure && make] returned a non-zero code: 1