### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM debian:wheezy
+FROM debian:10
 
 MAINTAINER Li Yichao <liyichao.good@gmail.com>
 
-COPY ./docker/sources.list /etc/apt/sources.list
+
 RUN	apt-get update && \
 	apt-get install -y --no-install-recommends \
 	build-essential \


### PR DESCRIPTION
Hello, I represent a research group investigating build failures in
Dockerfiles. We executed a Dockerfile in your project and found that
it is not building. We are sending this Pull Request with a suggested
repair. The repair operation is based on:

The base image is EOL (end of life), please seriously consider upgrading to a supported release.

Please note that we are using an anonymous GitHub account because of
double-blind restrictions in the submission process of conferences.
